### PR TITLE
Allow emitting to a Socket IO room

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ To install node-red-contrib-socketio use this command
 
 ## Composition
 The Socket.IO implementation is made with
-* 1 configuration Node that hold the server definitions ad the user can decide if bind SocketIO server on Node-RED port or bind it to anotherport
-* 1 input node where the user add all the possible `topic` sent from the client javascript code
-* 1 outpu node tath send data received into payload to the client browser
+* 1 configuration Node that holds the server definitions and the user can decide to bind the SocketIO server on the Node-RED port or bind it to another port
+* 1 input node where the user adds all the `topic`s in which they are interested
+* 1 output node that sends the data received into `msg.payload`
+* 1 node to join a Socket IO room
+* 1 node to leave a Socket IO room
 
 ## Usage
 To see an example usage go to [Example Chat App](https://flows.nodered.org/flow/71f7da3a14951acb67f94bac1f71812a)

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "node-red-contrib-socketio",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Implementation for Node-RED of a SocketIO Sever",
   "dependencies": {
     "socket.io": ">=1.5.1"
-    },
-  "node-red"     : {
-        "nodes": {
-            "socket-io": "socketio.js"
-        }
-    },
+  },
+  "node-red": {
+    "nodes": {
+      "socket-io": "socketio.js"
+    }
+  },
   "main": "socketio.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-socketio",
-  "version": "1.1.0",
+  "version": "1.0.6",
   "description": "Implementation for Node-RED of a SocketIO Sever",
   "dependencies": {
     "socket.io": ">=1.5.1"

--- a/socketio.html
+++ b/socketio.html
@@ -183,3 +183,81 @@
    <p><code>msg.socketIOAddStaticProperties</code> as <i>Object</i> = User defined properties to add to the socket (if already defined they will be overwriten)</p>
    <br />
 </script>
+
+<!-- node socketIO join, join a room-->
+<script type="text/javascript">
+    RED.nodes.registerType('socketio-join',{
+		category:"SocketIO",
+        color:"rgb(0, 230, 184)",
+		defaults:{
+			name: {value:""},
+			server: {value:"", required:true, type:"socketio-config"}
+		},
+		inputs: 1,
+		outputs: 0,
+		icon: "bridge.png",
+		label: function(){
+			return this.name || "SocketIO JOIN";
+		}		
+    });
+</script>
+
+<script type="text/x-red" data-template-name="socketio-join">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+	<div class="form-row">
+        <label for="node-input-server"><i class="fa fa-tag"></i> Server</label>
+        <input type="text" id="node-input-server">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="socketio-join">
+   <p>Socket IO Join node</p>
+   <p>Implementation of a SocketIO server</p>
+   <p>This node can be used to join a Socket IO room</p>
+   <br />
+   <p>This node accepts on input:</p>
+   <p><code>msg.payload.room</code> as <i>String</i> = room to join</p>
+   <br />
+</script>
+
+<!-- node socketIO leave, leave a room-->
+<script type="text/javascript">
+    RED.nodes.registerType('socketio-leave',{
+		category:"SocketIO",
+        color:"rgb(0, 230, 184)",
+		defaults:{
+			name: {value:""},
+			server: {value:"", required:true, type:"socketio-config"}
+		},
+		inputs: 1,
+		outputs: 0,
+		icon: "bridge.png",
+		label: function(){
+			return this.name || "SocketIO LEAVE";
+		}		
+    });
+</script>
+
+<script type="text/x-red" data-template-name="socketio-leave">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+	<div class="form-row">
+        <label for="node-input-server"><i class="fa fa-tag"></i> Server</label>
+        <input type="text" id="node-input-server">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="socketio-leave">
+   <p>Socket IO Leave node</p>
+   <p>Implementation of a SocketIO server</p>
+   <p>This node can be used to leave a Socket IO room</p>
+   <br />
+   <p>This node accepts on input:</p>
+   <p><code>msg.payload.room</code> as <i>String</i> = room to leave</p>
+   <br />
+</script>

--- a/socketio.html
+++ b/socketio.html
@@ -179,6 +179,7 @@
    <p>&nbsp;&nbsp; possibilities are :</p>
    <p>&nbsp;&nbsp;<code>broadcast.emit</code> as <i>String</i> = send to all sockets except this socket</p>
    <p>&nbsp;&nbsp;<code>emit</code> as <i>String</i> = send only to this socket</p>
+   <p>&nbsp;&nbsp;<code>room</code> as <i>String</i> = send to everyone in <code>msg.room</code></p>
    <p>&nbsp;&nbsp; not defined = send to all sockets</p>
    <p><code>msg.socketIOAddStaticProperties</code> as <i>Object</i> = User defined properties to add to the socket (if already defined they will be overwriten)</p>
    <br />

--- a/socketio.js
+++ b/socketio.js
@@ -139,6 +139,12 @@ module.exports = function(RED) {
 					}
 					//console.log("emit");
 					break;
+				case "room":
+				//emit to all
+				if(msg.room){
+					io.to(msg.room).emit(msg.socketIOEvent , msg.payload);
+				}
+				//console.log("io..to.emit");
 				default:
 				//emit to all
 				io.emit(msg.socketIOEvent , msg.payload);
@@ -148,9 +154,43 @@ module.exports = function(RED) {
 		
 	}
 	
+	function socketIoJoin(n) {
+		RED.nodes.createNode(this,n);
+		// node-specific code goes here
+		var node = this;
+		this.name = n.name;
+		this.server = RED.nodes.getNode(n.server);
+		
+		node.on('input', function(msg) {
+			if(io.sockets.sockets[RED.util.getMessageProperty(msg,"socketIOId")]){
+				io.sockets.sockets[RED.util.getMessageProperty(msg,"socketIOId")].join(msg.payload.room);
+				node.send(msg);
+			}
+		});
+	}
+	
+	function socketIoLeave(n) {
+		RED.nodes.createNode(this,n);
+		// node-specific code goes here
+		var node = this;
+		this.name = n.name;
+		this.server = RED.nodes.getNode(n.server);
+		
+		node.on('input', function(msg) {
+			if(io.sockets.sockets[RED.util.getMessageProperty(msg,"socketIOId")]){
+				io.sockets.sockets[RED.util.getMessageProperty(msg,"socketIOId")].join(msg.payload.room);
+				node.send(msg);
+			}
+		});
+	}
+	
+	
+	
 	
 
 	RED.nodes.registerType("socketio-config",socketIoConfig);
 	RED.nodes.registerType("socketio-in",socketIoIn);
 	RED.nodes.registerType("socketio-out",socketIoOut);
+	RED.nodes.registerType("socketio-join",socketIoJoin);
+	RED.nodes.registerType("socketio-leave",socketIoLeave);
 }


### PR DESCRIPTION
Allow emitting to a Socket IO room by creating 2 nodes, one to leave and one to join a room. 

The idea is that an in node would be attached to join and leave nodes and that a client would send  a message with the payload `{room: "Room Name"}`. The user can set what topics they'd like to use.

I've added in a `socketIOEmit` mode `room`, which will emit to `msg.room`.